### PR TITLE
Enable open_framework explicitly

### DIFF
--- a/Stanford/Jumpstart/Install/ThemeSettings.php
+++ b/Stanford/Jumpstart/Install/ThemeSettings.php
@@ -19,7 +19,7 @@ class ThemeSettings extends \AbstractInstallTask {
   public function execute(&$args = array()) {
 
     // Enable themes.
-    $themes = array('stanford_framework', 'stanford_seven');
+    $themes = array('stanford_framework', 'stanford_seven', 'open_framework');
     theme_enable($themes);
 
     variable_set('theme_default', 'stanford_framework');

--- a/Stanford/JumpstartVPSA/Install/Content/ImportJSVPSANodes.php
+++ b/Stanford/JumpstartVPSA/Install/Content/ImportJSVPSANodes.php
@@ -33,13 +33,14 @@ class ImportJSVPSANodes extends \AbstractInstallTask {
     $importer = new \SitesContentImporter();
     $importer->set_endpoint($endpoint);
     $importer->add_field_processor(array("body" => "\Stanford\Jumpstart\Install\Content\Importer\ImporterFieldProcessorCustomBody"));
+    $importer->add_field_processor(array("field_s_destination_publish" => "\Stanford\Jumpstart\Install\Content\Importer\ImporterFieldProcessorCustomFieldSDestinationPublish"));
     // Tell the importer what is what.
     $importer->add_import_content_type($content_types);
     // Calling this imports the 20 most recent of each content type.
     $importer->importer_content_nodes_recent_by_type();
 
-    // JSVPSA ONLY CONTENT - Tid 39 = JSVPSA.
-    $filters = array('sites_products' => array('39'));
+    // JSVPSA ONLY CONTENT: tid 39 = JSVPSA.
+    $filters = array('tid_raw' => array('39'));
     $view_importer = new \SitesContentImporterViews();
     $view_importer->set_endpoint($endpoint);
     $view_importer->set_resource('content');


### PR DESCRIPTION
I am finding that if we don't explicitly do this, it does not get enabled. Not 100% certain that sub-themes require that the parent theme be enabled, but it sounds like a good idea.
