### PR TITLE
Changes to block classes to support block_class-7.x-2.3 upgrayedd

### DIFF
--- a/Stanford/DrupalCamp/Install/BlockClass.php
+++ b/Stanford/DrupalCamp/Install/BlockClass.php
@@ -18,18 +18,17 @@ class BlockClass extends \AbstractInstallTask {
    */
   public function execute(&$args = array()) {
 
-    $fields = array('module', 'delta', 'css_class');
     $values = array(
       array("bean", "drupalcamp-propose-a-session-but", "well"),
     );
 
-    // Key all the values.
-    $insert = db_insert('block_class')->fields($fields);
     foreach ($values as $k => $value) {
-      $db_values = array_combine($fields, $value);
-      $insert->values($db_values);
+      // UPDATE block SET (module="bean",delta="social-media",css_class="span4") WHERE module="bean" AND delta="social-media
+      $update = db_update('block')->fields(array('css_class' => $value[2]));
+      $update->condition('module',$value[0]);
+      $update->condition('delta',$value[1]);
+      $update->execute();
     }
-    $insert->execute();
 
   }
 

--- a/Stanford/DrupalCamp/Install/BlockClass.php
+++ b/Stanford/DrupalCamp/Install/BlockClass.php
@@ -23,7 +23,7 @@ class BlockClass extends \AbstractInstallTask {
     );
 
     foreach ($values as $k => $value) {
-      // UPDATE block SET (module="bean",delta="social-media",css_class="span4") WHERE module="bean" AND delta="social-media
+      // UPDATE block SET (module="bean",delta="social-media",css_class="span4") WHERE module="bean" AND delta="social-media"
       $update = db_update('block')->fields(array('css_class' => $value[2]));
       $update->condition('module',$value[0]);
       $update->condition('delta',$value[1]);

--- a/Stanford/Jumpstart/Install/JumpstartSettings.php
+++ b/Stanford/Jumpstart/Install/JumpstartSettings.php
@@ -71,7 +71,7 @@ class JumpstartSettings extends \AbstractInstallTask {
 
 
     foreach ($values as $k => $value) {
-      // UPDATE block SET (module="bean",delta="social-media",css_class="span4") WHERE module="bean" AND delta="social-media
+      // UPDATE block SET (module="bean",delta="social-media",css_class="span4") WHERE module="bean" AND delta="social-media"
       $update = db_update('block')->fields(array('css_class' => $value[2]));
       $update->condition('module',$value[0]);
       $update->condition('delta',$value[1]);

--- a/Stanford/Jumpstart/Install/JumpstartSettings.php
+++ b/Stanford/Jumpstart/Install/JumpstartSettings.php
@@ -36,7 +36,7 @@ class JumpstartSettings extends \AbstractInstallTask {
     variable_set('contextual_block_class', $cbc_layouts);
 
     // Install block classes.
-    $fields = array('module', 'delta', 'css_class');
+    // $fields = array('module', 'delta', 'css_class');
     $values = array(
       array("bean", "social-media", "span4"),
       array("bean", "contact-block", "span4"),
@@ -73,8 +73,8 @@ class JumpstartSettings extends \AbstractInstallTask {
     foreach ($values as $k => $value) {
       // UPDATE block SET (module="bean",delta="social-media",css_class="span4") WHERE module="bean" AND delta="social-media
       $update = db_update('block')->fields(array('css_class' => $value[2]));
-      $update->condition($fields[0],$value[0]);
-      $update->condition($fields[1],$value[1]);
+      $update->condition('module',$value[0]);
+      $update->condition('delta',$value[1]);
       $update->execute();
     }
 

--- a/Stanford/Jumpstart/Install/JumpstartSettings.php
+++ b/Stanford/Jumpstart/Install/JumpstartSettings.php
@@ -71,8 +71,8 @@ class JumpstartSettings extends \AbstractInstallTask {
 
 
     foreach ($values as $k => $value) {
-      $db_values = array_combine($fields, $value);
-      $update = db_update('block')->fields($db_values);
+      // UPDATE block SET (module="bean",delta="social-media",css_class="span4") WHERE module="bean" AND delta="social-media
+      $update = db_update('block')->fields(array('css_class' => $value[2]));
       $update->condition($fields[0],$value[0]);
       $update->condition($fields[1],$value[1]);
       $update->execute();

--- a/Stanford/Jumpstart/Install/JumpstartSettings.php
+++ b/Stanford/Jumpstart/Install/JumpstartSettings.php
@@ -69,15 +69,15 @@ class JumpstartSettings extends \AbstractInstallTask {
       array("stanford_jumpstart_layouts", "jumpstart-launch", "shortcuts-launch-block"),
     );
 
-    // Key all the values.
-    $insert = db_insert('block_class')->fields($fields);
 
     foreach ($values as $k => $value) {
       $db_values = array_combine($fields, $value);
-      $insert->values($db_values);
+      $update = db_update('block')->fields($db_values);
+      $update->condition($fields[0],$value[0]);
+      $update->condition($fields[1],$value[1]);
+      $update->execute();
     }
 
-    $insert->execute();
 
   }
 
@@ -89,6 +89,7 @@ class JumpstartSettings extends \AbstractInstallTask {
       'cbc',
       'stanford_jumpstart',
       'stanford_jumpstart_home',
+      'block_class',
     );
   }
 

--- a/Stanford/JumpstartAcademic/Install/Block/BlockSettings.php
+++ b/Stanford/JumpstartAcademic/Install/Block/BlockSettings.php
@@ -116,7 +116,7 @@ class BlockSettings extends \AbstractInstallTask {
     );
 
     foreach ($values as $k => $value) {
-      // UPDATE block SET (module="bean",delta="social-media",css_class="span4") WHERE module="bean" AND delta="social-media
+      // UPDATE block SET (module="bean",delta="social-media",css_class="span4") WHERE module="bean" AND delta="social-media"
       $update = db_update('block')->fields(array('css_class' => $value[2]));
       $update->condition('module',$value[0]);
       $update->condition('delta',$value[1]);

--- a/Stanford/JumpstartAcademic/Install/Block/BlockSettings.php
+++ b/Stanford/JumpstartAcademic/Install/Block/BlockSettings.php
@@ -134,6 +134,7 @@ class BlockSettings extends \AbstractInstallTask {
       'system',
       'search',
       'user',
+      'block_class',
     );
   }
 

--- a/Stanford/JumpstartAcademic/Install/Block/BlockSettings.php
+++ b/Stanford/JumpstartAcademic/Install/Block/BlockSettings.php
@@ -32,7 +32,6 @@ class BlockSettings extends \AbstractInstallTask {
     variable_set('contextual_block_class', $cbc_layouts);
 
     // Block classes.
-    $fields = array('module', 'delta', 'css_class');
     $values = array(
       array("bean","jumpstart-home-page-about","well"),
       array("bean","homepage-about-block", 'well'),
@@ -116,13 +115,13 @@ class BlockSettings extends \AbstractInstallTask {
       array("bean","jumpstart-homepage-mission-blo-0","mission-block"),
     );
 
-    // Key all the values.
-    $insert = db_insert('block_class')->fields($fields);
     foreach ($values as $k => $value) {
-      $db_values = array_combine($fields, $value);
-      $insert->values($db_values);
+      // UPDATE block SET (module="bean",delta="social-media",css_class="span4") WHERE module="bean" AND delta="social-media
+      $update = db_update('block')->fields(array('css_class' => $value[2]));
+      $update->condition('module',$value[0]);
+      $update->condition('delta',$value[1]);
+      $update->execute();
     }
-    $insert->execute();
 
   }
 

--- a/Stanford/JumpstartEngineering/Install/Block/JSEBlockClasses.php
+++ b/Stanford/JumpstartEngineering/Install/Block/JSEBlockClasses.php
@@ -19,18 +19,25 @@ class JSEBlockClasses extends \AbstractInstallTask {
   public function execute(&$args = array()) {
 
     // Install default JSE block classes.
-    $fields = array('module', 'delta', 'css_class');
     $values = array(
       array("bean", "jumpstart-small-custom-block", "well"),
       array("bean", "jumpstart-large-custom-block", "well"),
     );
-    // Key all the values.
-    $insert = db_insert('block_class')->fields($fields);
-    foreach ($values as $value) {
-      $db_values = array_combine($fields, $value);
-      $insert->values($db_values);
+    foreach ($values as $k => $value) {
+      // UPDATE block SET (module="bean",delta="social-media",css_class="span4") WHERE module="bean" AND delta="social-media
+      $update = db_update('block')->fields(array('css_class' => $value[2]));
+      $update->condition('module',$value[0]);
+      $update->condition('delta',$value[1]);
+      $update->execute();
     }
-    $insert->execute();
+  }
+  /**
+   *
+   */
+  public function requirements() {
+    return array(
+      'block_class',
+    );
   }
 
 }

--- a/Stanford/JumpstartEngineering/Install/Block/JSEBlockClasses.php
+++ b/Stanford/JumpstartEngineering/Install/Block/JSEBlockClasses.php
@@ -24,7 +24,7 @@ class JSEBlockClasses extends \AbstractInstallTask {
       array("bean", "jumpstart-large-custom-block", "well"),
     );
     foreach ($values as $k => $value) {
-      // UPDATE block SET (module="bean",delta="social-media",css_class="span4") WHERE module="bean" AND delta="social-media
+      // UPDATE block SET (module="bean",delta="social-media",css_class="span4") WHERE module="bean" AND delta="social-media"
       $update = db_update('block')->fields(array('css_class' => $value[2]));
       $update->condition('module',$value[0]);
       $update->condition('delta',$value[1]);

--- a/Stanford/JumpstartPlus/Install/Block/BlockSettings.php
+++ b/Stanford/JumpstartPlus/Install/Block/BlockSettings.php
@@ -113,7 +113,7 @@ class BlockSettings extends \AbstractInstallTask {
     );
 
     foreach ($values as $k => $value) {
-      // UPDATE block SET (module="bean",delta="social-media",css_class="span4") WHERE module="bean" AND delta="social-media
+      // UPDATE block SET (module="bean",delta="social-media",css_class="span4") WHERE module="bean" AND delta="social-media"
       $update = db_update('block')->fields(array('css_class' => $value[2]));
       $update->condition('module',$value[0]);
       $update->condition('delta',$value[1]);

--- a/Stanford/JumpstartPlus/Install/Block/BlockSettings.php
+++ b/Stanford/JumpstartPlus/Install/Block/BlockSettings.php
@@ -32,7 +32,6 @@ class BlockSettings extends \AbstractInstallTask {
     variable_set('contextual_block_class', $cbc_layouts);
 
     // Block clases.
-    $fields = array('module', 'delta', 'css_class');
     $values = array(
       array("bean","jumpstart-home-page-about","well"),
       array("bean","homepage-about-block", 'well'),
@@ -113,13 +112,13 @@ class BlockSettings extends \AbstractInstallTask {
       array("views","ad215e0528148b386833fa3db1f3b7dc","well"),
     );
 
-    // Key all the values.
-    $insert = db_insert('block_class')->fields($fields);
     foreach ($values as $k => $value) {
-      $db_values = array_combine($fields, $value);
-      $insert->values($db_values);
+      // UPDATE block SET (module="bean",delta="social-media",css_class="span4") WHERE module="bean" AND delta="social-media
+      $update = db_update('block')->fields(array('css_class' => $value[2]));
+      $update->condition('module',$value[0]);
+      $update->condition('delta',$value[1]);
+      $update->execute();
     }
-    $insert->execute();
 
   }
 
@@ -133,6 +132,7 @@ class BlockSettings extends \AbstractInstallTask {
       'user',
       'bean',
       'block',
+      'block_class'
     );
   }
 

--- a/Stanford/JumpstartVPSA/Install/Block/JSVPSABlockClasses.php
+++ b/Stanford/JumpstartVPSA/Install/Block/JSVPSABlockClasses.php
@@ -20,7 +20,6 @@ class JSVPSABlockClasses extends \AbstractInstallTask {
 
 
     // Install block classes:
-    $fields = array('module', 'delta', 'css_class');
     $values = array(
       array("bean", "flexi-block-for-the-home-page", "well span4 clear-row"),
       array("bean", "homepage-about-block", "well"),
@@ -56,13 +55,22 @@ class JSVPSABlockClasses extends \AbstractInstallTask {
         "shortcuts-launch-block"
       ),
     );
-    // Key all the values.
-    $insert = db_insert('block_class')->fields($fields);
-    foreach ($values as $value) {
-      $db_values = array_combine($fields, $value);
-      $insert->values($db_values);
+    foreach ($values as $k => $value) {
+      // UPDATE block SET (module="bean",delta="social-media",css_class="span4") WHERE module="bean" AND delta="social-media"
+      $update = db_update('block')->fields(array('css_class' => $value[2]));
+      $update->condition('module',$value[0]);
+      $update->condition('delta',$value[1]);
+      $update->execute();
     }
-    $insert->execute();
+  }
+
+  /**
+   *
+   */
+  public function requirements() {
+    return array(
+      'block_class',
+    );
   }
 
 }


### PR DESCRIPTION
**READY**

To test:
1. Build an environment with the `stable20160622` branch of `stanford-jumpstart-deployer`
2. Check out this `block_class_update` branch in `sites/all/libraries/tasks`
3. Install your chosen product

If it installs cleanly and the blocks have the correct classes (e.g., `well` classes on homepage blocks), you're good to go.

I have tested on all products except DrupalCamp.

Comments on the logic of the implementation also are welcome.
