### PR TITLE
HSDO-489: filtered_html block formats

### DIFF
--- a/Stanford/DrupalProfile/Install/WYSIWYGSettings.php
+++ b/Stanford/DrupalProfile/Install/WYSIWYGSettings.php
@@ -56,9 +56,7 @@ class WYSIWYGSettings extends \AbstractInstallTask {
         'remove_linebreaks' => 1,
         'apply_source_formatting' => 1,
         'paste_auto_cleanup_on_paste' => 1,
-        'block_formats' => array(
-          "p", "address", "pre", "h2", "h3", "h4", "h5", "h6",
-        ),
+        'block_formats' => "p,address,pre,h2,h3,h4,h5,h6",
         'css_setting' => 'theme',
         'css_path' => '',
         'css_classes' => ''


### PR DESCRIPTION
# Ready for Review

Changes install task for filtered_input wysiwyg so that it doesnt cause mb_strtolower php error

**TO TEST**
- Install a new JS(x) website with this branch of the tasks
- Change PHP error reporting for the site to show all errors (drush vset error_level 2)
- Go to a node/edit page and clear the cache
- See no php errors
- Toggle the input format to different options
- Validate that all of the block options are available in the filtered_html format drop down
- Refresh page and ensure still no PHP errors
- Check watchdog logs for PHP errors

If all is good then rejoice. 
