### PR TITLE
HSDO-597: Fixed default importer settings to work with labs_default mapping

### DIFF
--- a/Stanford/JumpstartLab/Install/CAPx/CAPxConfigChange.php
+++ b/Stanford/JumpstartLab/Install/CAPx/CAPxConfigChange.php
@@ -18,11 +18,25 @@ class CAPxConfigChange extends AbstractInstallTask {
   public function execute(&$args = array()) {
     db_update('capx_cfe')
       ->fields(array(
-        'machine_name' => 'labs_defaulta',
+        'machine_name' => 'labs_default',
         'title' => t('LABs Default'),
       ))
       ->condition('machine_name', 'jse_default')
       ->execute();
+    $importer_settings = db_select('capx_cfe', 'c')
+      ->fields('c', array('cfid', 'settings'))
+      ->condition('type', 'importer')
+      ->execute();
+    while ($importer = $importer_settings->fetchAssoc()) {
+      $settings = $importer['settings'];
+      $settings = unserialize($settings);
+      $settings['mapper'] = 'labs_default';
+      db_update('capx_cfe')
+        ->condition('cfid', $importer['cfid'])
+        ->fields(array('settings' => serialize($settings)))
+        ->execute();
+    }
+
   }
 
 }


### PR DESCRIPTION
To Test:
Build a jsl using 7.x-5.x branch
checkout HSDO-597 of the install tasks
Install site
check CAPx importer and mapper settings.