### PR TITLE
Update CAPxConfig.php

### DIFF
--- a/Stanford/JumpstartEngineering/Install/CAPx/CAPxConfig.php
+++ b/Stanford/JumpstartEngineering/Install/CAPx/CAPxConfig.php
@@ -177,6 +177,9 @@ class CAPxConfig extends AbstractInstallTask {
       'collections' => array(),
       'entity_type' => 'node',
       'bundle_type' => 'stanford_person',
+      'multiple' => 0,
+      'subquery' => '',
+      'guuidquery' => '',
       'title' => t("Default"),
     );
     // JSE Default.
@@ -273,6 +276,9 @@ class CAPxConfig extends AbstractInstallTask {
       'collections' => array(),
       'entity_type' => 'node',
       'bundle_type' => 'stanford_person',
+      'multiple' => 0,
+      'subquery' => '',
+      'guuidquery' => '',
       'title' => t("JSE Default"),
     );
     return $mappers;


### PR DESCRIPTION
To fix the problem with missing guuidquery

But long term you should move this from the install profile to a feature as 3.0 is now compatible. 