### PR TITLE
Add an option to specify the file_temporary_path

### DIFF
--- a/Stanford/DrupalProfile/Install/StanfordSites/TMPDir.php
+++ b/Stanford/DrupalProfile/Install/StanfordSites/TMPDir.php
@@ -33,9 +33,9 @@ class TMPDir extends AbstractInstallTask {
   /**
    * Add a form element for gathering the path to the temporary files directory.
    *
-   * @param $form
+   * @param array $form
    *   The form.
-   * @param $form_state
+   * @param array $form_state
    *   The form state.
    */
   public function form(&$form, &$form_state) {

--- a/Stanford/DrupalProfile/Install/StanfordSites/TMPDir.php
+++ b/Stanford/DrupalProfile/Install/StanfordSites/TMPDir.php
@@ -33,7 +33,7 @@ class TMPDir extends AbstractInstallTask {
   /**
    * Add a form element for gathering the path to the temporary files directory.
    *
-   * @param array $form
+   * @param array|mixed $form
    *   The form.
    * @param array $form_state
    *   The form state.

--- a/Stanford/DrupalProfile/Install/StanfordSites/TMPDir.php
+++ b/Stanford/DrupalProfile/Install/StanfordSites/TMPDir.php
@@ -38,12 +38,12 @@ class TMPDir extends AbstractInstallTask {
    * @param array $form_state
    *   The form state.
    */
-  public function form(array &$form = array(), array &$form_state = array()) {
+  public function form(&$form, &$form_state) {
     $form['sites']['stanford_sites_tmpdir'] = array(
       '#default_value' => '',
       "#type" => "textfield",
       "#title" => t("Temporary Files Directory"),
-      "#description" => t('Enter a path for the temporary files directory (e.g., "sites/default/files/tmp".'),
+      "#description" => t('Enter a path for the temporary files directory (e.g., "sites/default/files/tmp").'),
     );
   }
 

--- a/Stanford/DrupalProfile/Install/StanfordSites/TMPDir.php
+++ b/Stanford/DrupalProfile/Install/StanfordSites/TMPDir.php
@@ -35,7 +35,7 @@ class TMPDir extends AbstractInstallTask {
    *
    * @param array|mixed $form
    *   The form.
-   * @param array $form_state
+   * @param array|mixed $form_state
    *   The form state.
    */
   public function form(&$form, &$form_state) {

--- a/Stanford/DrupalProfile/Install/StanfordSites/TMPDir.php
+++ b/Stanford/DrupalProfile/Install/StanfordSites/TMPDir.php
@@ -16,18 +16,28 @@ class TMPDir extends AbstractInstallTask {
    *  Installation arguments.
    */
   public function execute(&$args = array()) {
+    // Set the variable from the form input, in case we want to use it later.
     variable_set('stanford_sites_tmpdir', $args['forms']['install_configure_form']['stanford_sites_tmpdir']);
     $tmpdir = variable_get('stanford_sites_tmpdir', file_directory_temp());
+    // Perms on the directory.
     file_prepare_directory($tmpdir, FILE_CREATE_DIRECTORY);
     // system_check_directory() is expecting a $form_element array.
     $element = array();
     $element['#value'] = $tmpdir;
-
     // Check that the temp directory exists; create it if it does not.
     system_check_directory($element);
+    // Actually set the temporary directory path to our desired path.
     variable_set('file_temporary_path', $tmpdir);
-
   }
+
+  /**
+   * Add a form element for gathering the path to the temporary files directory.
+   *
+   * @param $form
+   *   The form.
+   * @param $form_state
+   *   The form state.
+   */
   public function form(&$form, &$form_state) {
     $form['sites']['stanford_sites_tmpdir'] = array(
       '#default_value' => '',
@@ -36,5 +46,5 @@ class TMPDir extends AbstractInstallTask {
       "#description" => t('Enter a path for the temporary files directory (e.g., "sites/default/files/tmp".'),
     );
   }
-}
 
+}

--- a/Stanford/DrupalProfile/Install/StanfordSites/TMPDir.php
+++ b/Stanford/DrupalProfile/Install/StanfordSites/TMPDir.php
@@ -16,17 +16,25 @@ class TMPDir extends AbstractInstallTask {
    *  Installation arguments.
    */
   public function execute(&$args = array()) {
-
+    variable_set('stanford_sites_tmpdir', $args['forms']['install_configure_form']['stanford_sites_tmpdir']);
     $tmpdir = variable_get('stanford_sites_tmpdir', file_directory_temp());
     file_prepare_directory($tmpdir, FILE_CREATE_DIRECTORY);
-
     // system_check_directory() is expecting a $form_element array.
     $element = array();
     $element['#value'] = $tmpdir;
 
     // Check that the temp directory exists; create it if it does not.
     system_check_directory($element);
+    variable_set('file_temporary_path', $tmpdir);
 
   }
-
+  public function form(&$form, &$form_state) {
+    $form['sites']['stanford_sites_tmpdir'] = array(
+      '#default_value' => '',
+      "#type" => "textfield",
+      "#title" => t("Temporary Files Directory"),
+      "#description" => t('Enter a path for the temporary files directory (e.g., "sites/default/files/tmp".'),
+    );
+  }
 }
+

--- a/Stanford/DrupalProfile/Install/StanfordSites/TMPDir.php
+++ b/Stanford/DrupalProfile/Install/StanfordSites/TMPDir.php
@@ -38,7 +38,7 @@ class TMPDir extends AbstractInstallTask {
    * @param array $form_state
    *   The form state.
    */
-  public function form(&$form = array(), &$form_state = array()) {
+  public function form(array &$form = array(), array &$form_state = array()) {
     $form['sites']['stanford_sites_tmpdir'] = array(
       '#default_value' => '',
       "#type" => "textfield",

--- a/Stanford/DrupalProfile/Install/StanfordSites/TMPDir.php
+++ b/Stanford/DrupalProfile/Install/StanfordSites/TMPDir.php
@@ -38,7 +38,7 @@ class TMPDir extends AbstractInstallTask {
    * @param array $form_state
    *   The form state.
    */
-  public function form(&$form, &$form_state) {
+  public function form(&$form = array(), &$form_state = array()) {
     $form['sites']['stanford_sites_tmpdir'] = array(
       '#default_value' => '',
       "#type" => "textfield",


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Be able to specify `file_temporary_path` at install time

# Needed By (Date)
- ASAP

# Urgency
- Ghost pepper hot

# Steps to Test

1. Build a product with this branch of `stanford_install_tasks`
2. Install with the `install_configure_form.stanford_sites_tmpdir="sites/default/files/tmp"` option
3. Verify that your `file_temporary_path` variable is `sites/default/files/tmp`

# Affected Projects or Products
- All products
- Stanford Sites

# Associated Issues and/or People
- https://github.com/SU-SWS/stanford_sites_build/pull/5
- [HSDO-795](https://stanfordits.atlassian.net/browse/HSDO-795)
- Anyone who should be notified? ( @pookmish @annawatt )

