### PR TITLE
HSDO-892 Removed login block for JSA & Labs

### DIFF
--- a/Stanford/JumpstartAcademic/Install/Block/BlockSettings.php
+++ b/Stanford/JumpstartAcademic/Install/Block/BlockSettings.php
@@ -107,9 +107,9 @@ class BlockSettings extends AbstractInstallTask {
       array("views", "99107f9408b38333b7b9429d6f180b75", "well"),
       // Person list.
       array("views", "84a0a512b3e0ccb8042a7d3b418168d7", "well"),
-      //Person Directory.
+      // Person Directory.
       array("views", "385e44d327c496fd55fac99bf18f15d9", "well"),
-      //Person Grouped Directory.
+      // Person Grouped Directory.
       array("views", "e37f035f29edbe11736c3500a7ea43a7", "well"),
 
       // Panama.

--- a/Stanford/JumpstartAcademic/Install/Block/BlockSettings.php
+++ b/Stanford/JumpstartAcademic/Install/Block/BlockSettings.php
@@ -5,6 +5,7 @@
  */
 
 namespace Stanford\JumpstartAcademic\Install\Block;
+
 use \ITasks\AbstractInstallTask;
 
 /**
@@ -35,100 +36,118 @@ class BlockSettings extends AbstractInstallTask {
 
     // Block classes.
     $values = array(
-      array("bean","jumpstart-home-page-about","well"),
-      array("bean","homepage-about-block", 'well'),
-      array("bean","jumpstart-home-page-information-",'well'),
-      array("bean","jumpstart-affiliated-programs","well"),
-      array("bean","jumpstart-contact-us-postcard","well"),
-      array("bean","jumpstart-degree-programs-info-f","well"),
-      array("bean","jumpstart-featured-course","well"),
-      array("bean","jumpstart-featured-event","well"),
-      array("bean","jumpstart-featured-event-block","well"),
-      array("bean","jumpstart-footer-contact-block","span2"),
-      array("bean","jumpstart-footer-social-media--0","span2"),
-      array("bean","jumpstart-footer-social-media-co","span4"),
-      array("bean","jumpstart-graduate-student-sideb","well"),
-      array("bean","jumpstart-home-page-academics","well"),
-      array("bean","jumpstart-info-for-current-gra-0","span4 well"),
-      array("bean","jumpstart-info-for-current-gra-1","span4 well"),
-      array("bean","jumpstart-info-for-current-gradu","span4 well"),
-      array("bean","jumpstart-info-for-current-und-0","span4 well"),
-      array("bean","jumpstart-info-for-current-und-1","span4 well"),
-      array("bean","jumpstart-info-for-current-under","span4 well"),
-      array("bean","jumpstart-info-for-prospective-0","span4 well"),
-      array("bean","jumpstart-info-for-prospective-1","span4 well"),
-      array("bean","jumpstart-info-for-prospective-g","span4 well"),
-      array("bean","jumpstart-twitter-block","well"),
-      array("bean","jumpstart-why-i-teach","well"),
-      array("bean","jumpstart-why-i-teach-block","well"),
-      array("bean","optional-footer-block","span4"),
-      array("bean","social-media","span4"),
-      array("ds_extras","contact","well"),
-      array("ds_extras","office_hours","well"),
-      array("menu","menu-admin-shortcuts-add-feature","shortcuts-features"),
-      array("menu","menu-admin-shortcuts-get-help","shortcuts-help"),
-      array("menu","menu-admin-shortcuts-home","shortcuts-home"),
-      array("menu","menu-admin-shortcuts-logout-link","shortcuts-logout"),
-      array("menu","menu-admin-shortcuts-ready-to-la","shortcuts-launch"),
-      array("menu","menu-admin-shortcuts-site-action","shortcuts-actions shortcuts-dropdown"),
-      array("menu","menu-footer-news-events-menu","span2"),
-      array("menu","menu-footer-people-menu","span2"),
-      array("menu","menu-footer-academics-menu","span2"),
-      array("menu","menu-footer-about-menu","span2"),
-      array("stanford_jumpstart_layouts","jumpstart-launch","shortcuts-launch-block"),
-      array("views","-exp-publications-page","well"),
-      array("views","f73ff55b085ea49217d347de6630cd5a","well"),
-      array("views","jumpstart_current_user-block","shortcuts-user"),
-      array("views","publications_common-block_4","well"),
-      array("views","stanford_news-block","well"),
-      array("views","stanford_events_views-block","well"),
-      array("views","-exp-stanford_person_staff-page","well"),
-      array("views","-exp-stanford_news-page_1","well"),
-      array("views","-exp-courses-search_page","well"),
-      array("views","442e92af913370af5bffd333a036ceaa","well"),
-      array("views","b38da907588eed2d09c10bdb381e5aaf","well"),
-      array("views","4066d038591af2b511f66557e5ac41e8","well"),
-      array("views","2d9147be40cd77d32915a554bf315858","well"),
-      array("views","85c57f65aa0dee37d8aa5a5031e564bc","well"),
-      array("views","5c84bdc5ea8289bceed723799d38940f","well"),
-      array("views","ad215e0528148b386833fa3db1f3b7dc","well"),
-      array("views","-exp-stanford_events_views-page", "well"),
-      array("views","-exp-stanford_person_grid-page", "well"),   // Person Grid
-      array("views","99107f9408b38333b7b9429d6f180b75", "well"), // Person list
-      array("views","84a0a512b3e0ccb8042a7d3b418168d7", "well"),  //Person Directory
-      array("views","385e44d327c496fd55fac99bf18f15d9", "well"),  //Person Grouped Directory
-      array("views","e37f035f29edbe11736c3500a7ea43a7", "well"),  //Person Profile
+      array("bean", "jumpstart-home-page-about", "well"),
+      array("bean", "homepage-about-block", 'well'),
+      array("bean", "jumpstart-home-page-information-", 'well'),
+      array("bean", "jumpstart-affiliated-programs", "well"),
+      array("bean", "jumpstart-contact-us-postcard", "well"),
+      array("bean", "jumpstart-degree-programs-info-f", "well"),
+      array("bean", "jumpstart-featured-course", "well"),
+      array("bean", "jumpstart-featured-event", "well"),
+      array("bean", "jumpstart-featured-event-block", "well"),
+      array("bean", "jumpstart-footer-contact-block", "span2"),
+      array("bean", "jumpstart-footer-social-media--0", "span2"),
+      array("bean", "jumpstart-footer-social-media-co", "span4"),
+      array("bean", "jumpstart-graduate-student-sideb", "well"),
+      array("bean", "jumpstart-home-page-academics", "well"),
+      array("bean", "jumpstart-info-for-current-gra-0", "span4 well"),
+      array("bean", "jumpstart-info-for-current-gra-1", "span4 well"),
+      array("bean", "jumpstart-info-for-current-gradu", "span4 well"),
+      array("bean", "jumpstart-info-for-current-und-0", "span4 well"),
+      array("bean", "jumpstart-info-for-current-und-1", "span4 well"),
+      array("bean", "jumpstart-info-for-current-under", "span4 well"),
+      array("bean", "jumpstart-info-for-prospective-0", "span4 well"),
+      array("bean", "jumpstart-info-for-prospective-1", "span4 well"),
+      array("bean", "jumpstart-info-for-prospective-g", "span4 well"),
+      array("bean", "jumpstart-twitter-block", "well"),
+      array("bean", "jumpstart-why-i-teach", "well"),
+      array("bean", "jumpstart-why-i-teach-block", "well"),
+      array("bean", "optional-footer-block", "span4"),
+      array("bean", "social-media", "span4"),
+      array("ds_extras", "contact", "well"),
+      array("ds_extras", "office_hours", "well"),
+      array("menu", "menu-admin-shortcuts-add-feature", "shortcuts-features"),
+      array("menu", "menu-admin-shortcuts-get-help", "shortcuts-help"),
+      array("menu", "menu-admin-shortcuts-home", "shortcuts-home"),
+      array("menu", "menu-admin-shortcuts-logout-link", "shortcuts-logout"),
+      array("menu", "menu-admin-shortcuts-ready-to-la", "shortcuts-launch"),
+      array(
+        "menu",
+        "menu-admin-shortcuts-site-action",
+        "shortcuts-actions shortcuts-dropdown",
+      ),
+      array("menu", "menu-footer-news-events-menu", "span2"),
+      array("menu", "menu-footer-people-menu", "span2"),
+      array("menu", "menu-footer-academics-menu", "span2"),
+      array("menu", "menu-footer-about-menu", "span2"),
+      array(
+        "stanford_jumpstart_layouts",
+        "jumpstart-launch",
+        "shortcuts-launch-block",
+      ),
+      array("views", "-exp-publications-page", "well"),
+      array("views", "f73ff55b085ea49217d347de6630cd5a", "well"),
+      array("views", "jumpstart_current_user-block", "shortcuts-user"),
+      array("views", "publications_common-block_4", "well"),
+      array("views", "stanford_news-block", "well"),
+      array("views", "stanford_events_views-block", "well"),
+      array("views", "-exp-stanford_person_staff-page", "well"),
+      array("views", "-exp-stanford_news-page_1", "well"),
+      array("views", "-exp-courses-search_page", "well"),
+      array("views", "442e92af913370af5bffd333a036ceaa", "well"),
+      array("views", "b38da907588eed2d09c10bdb381e5aaf", "well"),
+      array("views", "4066d038591af2b511f66557e5ac41e8", "well"),
+      array("views", "2d9147be40cd77d32915a554bf315858", "well"),
+      array("views", "85c57f65aa0dee37d8aa5a5031e564bc", "well"),
+      array("views", "5c84bdc5ea8289bceed723799d38940f", "well"),
+      array("views", "ad215e0528148b386833fa3db1f3b7dc", "well"),
+      array("views", "-exp-stanford_events_views-page", "well"),
+      array("views", "-exp-stanford_person_grid-page", "well"),
+      // Person Grid.
+      array("views", "99107f9408b38333b7b9429d6f180b75", "well"),
+      // Person list.
+      array("views", "84a0a512b3e0ccb8042a7d3b418168d7", "well"),
+      //Person Directory.
+      array("views", "385e44d327c496fd55fac99bf18f15d9", "well"),
+      //Person Grouped Directory.
+      array("views", "e37f035f29edbe11736c3500a7ea43a7", "well"),
 
-      // Panama
-      array("bean","homepage-banner-image","span8"),
+      // Panama.
+      array("bean", "homepage-banner-image", "span8"),
 
-      // Lomita
-      array("bean","jumpstart-postcard-with-video","span6"),
+      // Lomita.
+      array("bean", "jumpstart-postcard-with-video", "span6"),
 
-      // Mayfield
-      array("bean","jumpstart-homepage-testimonial-b","span6"),
+      // Mayfield.
+      array("bean", "jumpstart-homepage-testimonial-b", "span6"),
 
-      // Palm
-      array("bean","jumpstart-homepage-tall-banner","span12"),
+      // Palm.
+      array("bean", "jumpstart-homepage-tall-banner", "span12"),
 
-      // Serra
-      array("bean","jumpstart-info-text-block","span3"),
-      array("bean","jumpstart-homepage-mission-block","mission-block"),
-      array("bean","jumpstart-homepage-mission-blo-0","mission-block"),
+      // Serra.
+      array("bean", "jumpstart-info-text-block", "span3"),
+      array("bean", "jumpstart-homepage-mission-block", "mission-block"),
+      array("bean", "jumpstart-homepage-mission-blo-0", "mission-block"),
     );
 
     foreach ($values as $k => $value) {
       // UPDATE block SET (module="bean",delta="social-media",css_class="span4") WHERE module="bean" AND delta="social-media"
       $update = db_update('block')->fields(array('css_class' => $value[2]));
-      $update->condition('module',$value[0]);
-      $update->condition('delta',$value[1]);
+      $update->condition('module', $value[0]);
+      $update->condition('delta', $value[1]);
       $update->execute();
     }
 
+    db_update('block')
+      ->fields(array('status' => 0))
+      ->condition('module', 'webauth')
+      ->condition('delta', 'webauth_login_block')
+      ->execute();
   }
 
   /**
    * [requirements description]
+   *
    * @return [type] [description]
    */
   public function requirements() {

--- a/Stanford/JumpstartAcademic/Install/GeneralSettings.php
+++ b/Stanford/JumpstartAcademic/Install/GeneralSettings.php
@@ -28,6 +28,17 @@ class GeneralSettings extends AbstractInstallTask {
 
     // Set menu position default setting to 'mark the rule's parent menu item as being "active".'
     variable_set('menu_position_active_link_display', 'parent');
+
+    $redirect = (object) array(
+      'type' => 'redirect',
+      'source' => 'login',
+      'source_options' => array(),
+      'redirect' => 'user',
+      'redirect_options' => array(),
+      'status_code' => 0,
+    );
+    redirect_save($redirect);
+    node_access_rebuild();
   }
 
 }

--- a/Stanford/JumpstartLab/Install/Block/BlockSettings.php
+++ b/Stanford/JumpstartLab/Install/Block/BlockSettings.php
@@ -141,6 +141,12 @@ class BlockSettings extends AbstractInstallTask {
       $update->condition('delta', $value[1]);
       $update->execute();
     }
+
+    db_update('block')
+      ->fields(array('status' => 0))
+      ->condition('module', 'webauth')
+      ->condition('delta', 'webauth_login_block')
+      ->execute();
   }
 
   /**

--- a/Stanford/JumpstartLab/Install/GeneralSettings.php
+++ b/Stanford/JumpstartLab/Install/GeneralSettings.php
@@ -28,6 +28,17 @@ class GeneralSettings extends AbstractInstallTask {
     // Set menu position default setting to 'mark the rule's parent menu item
     // as being "active"'.
     variable_set('menu_position_active_link_display', 'parent');
+
+    $redirect = (object) array(
+      'type' => 'redirect',
+      'source' => 'login',
+      'source_options' => array(),
+      'redirect' => 'user',
+      'redirect_options' => array(),
+      'status_code' => 0,
+    );
+    redirect_save($redirect);
+    node_access_rebuild();
   }
 
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Hide the webauth login links block from JSA & Labs.
- Redirect for /login to go to /user page.

# Needed By (Date)
- 6/22

# Urgency
- not urgent

# Steps to Test

1. run sites build of JSA or labs `grunt build:make:install --build-environment=sites`
2. verify that the login link appears
3. checkout this branch and reinstall: `drush si install_profile -y`
4. verify login link does not appear.
5. go to /login, verify it goes to /user