### PR TITLE
BASIC-2410: SUNet User is not getting created properly

### DIFF
--- a/Environment/Sites/Install/User/SunetUser.php
+++ b/Environment/Sites/Install/User/SunetUser.php
@@ -45,7 +45,7 @@ class SunetUser extends AbstractInstallTask {
     $roles = array(DRUPAL_AUTHENTICATED_RID => TRUE, $sunetrole->rid => TRUE, $ownerrole->rid => TRUE);
     $account->roles = $roles;
     $account->timezone = variable_get('date_default_timezone', '');
-    drush_log(print_r($account), "ok");
+    
     $account = user_save($account);
     user_set_authmaps($account, array('authname_webauth' => $authname));
   }

--- a/Environment/Sites/Install/User/SunetUser.php
+++ b/Environment/Sites/Install/User/SunetUser.php
@@ -42,10 +42,14 @@ class SunetUser extends AbstractInstallTask {
     $account->mail = $email;
     $account->init = $authname;
     $account->status = TRUE;
-    $roles = array(DRUPAL_AUTHENTICATED_RID => TRUE, $sunetrole->rid => TRUE, $ownerrole->rid => TRUE);
+    $roles = array(
+      DRUPAL_AUTHENTICATED_RID => TRUE,
+      $sunetrole->rid => TRUE,
+      $ownerrole->rid => TRUE
+    );
     $account->roles = $roles;
     $account->timezone = variable_get('date_default_timezone', '');
-    
+
     $account = user_save($account);
     user_set_authmaps($account, array('authname_webauth' => $authname));
   }

--- a/Environment/Sites/Install/User/SunetUser.php
+++ b/Environment/Sites/Install/User/SunetUser.php
@@ -26,7 +26,6 @@ class SunetUser extends AbstractInstallTask {
     $sunet = $args['forms']['install_configure_form']['stanford_sites_requester_sunetid'];
     $fullname = $args['forms']['install_configure_form']['stanford_sites_requester_name'];
     $email = $args['forms']['install_configure_form']['stanford_sites_requester_email'];
-
     $authname = $sunet . '@stanford.edu';
     $sunetrole = user_role_load_by_name('SUNet User');
     $ownerrole = user_role_load_by_name('site owner');
@@ -45,7 +44,7 @@ class SunetUser extends AbstractInstallTask {
     $roles = array(
       DRUPAL_AUTHENTICATED_RID => TRUE,
       $sunetrole->rid => TRUE,
-      $ownerrole->rid => TRUE
+      $ownerrole->rid => TRUE,
     );
     $account->roles = $roles;
     $account->timezone = variable_get('date_default_timezone', '');

--- a/Environment/Sites/Install/User/SunetUser.php
+++ b/Environment/Sites/Install/User/SunetUser.php
@@ -24,29 +24,29 @@ class SunetUser extends AbstractInstallTask {
     require_once DRUPAL_ROOT . '/includes/password.inc';
 
     $sunet = $args['forms']['install_configure_form']['stanford_sites_requester_sunetid'];
-    $fullName = $args['forms']['install_configure_form']['stanford_sites_requester_name'];
+    $fullname = $args['forms']['install_configure_form']['stanford_sites_requester_name'];
     $email = $args['forms']['install_configure_form']['stanford_sites_requester_email'];
 
-    $authName = $sunet . '@stanford.edu';
-    $sunetRole = user_role_load_by_name('SUNet User');
-    $ownerRole = user_role_load_by_name('site owner');
+    $authname = $sunet . '@stanford.edu';
+    $sunetrole = user_role_load_by_name('SUNet User');
+    $ownerrole = user_role_load_by_name('site owner');
 
-    if (!is_numeric($sunetRole->rid) || !is_numeric($ownerRole->rid)) {
+    if (!is_numeric($sunetrole->rid) || !is_numeric($ownerrole->rid)) {
       throw new \Exception("A role or roles were missing when trying to create a sunet user");
     }
 
     $account = new \stdClass();
     $account->is_new = TRUE;
-    $account->name = $fullName;
+    $account->name = $fullname;
     $account->pass = user_hash_password(user_password());
     $account->mail = $email;
     $account->init = $authname;
     $account->status = TRUE;
-    $roles = array(DRUPAL_AUTHENTICATED_RID => TRUE, $sunetRole->rid => TRUE, $ownerRole->rid => TRUE);
+    $roles = array(DRUPAL_AUTHENTICATED_RID => TRUE, $sunetrole->rid => TRUE, $ownerrole->rid => TRUE);
     $account->roles = $roles;
     $account->timezone = variable_get('date_default_timezone', '');
+    drush_log(print_r($account), "ok");
     $account = user_save($account);
-
     user_set_authmaps($account, array('authname_webauth' => $authname));
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Correctly creates the user and sets the authmap

# Needed By (Date)
- ASAP

# Criticality
- How critical is this PR on a 1-10 scale? 8
- Affects all JS* sites

# Steps to Test

1. Roll a JS* site and check out this branch in `sites/all/libraries/tasks`
2. Run this site install command (it should even work on local):
```
drush -y si stanford_sites_jumpstart install_configure_form.stanford_sites_org_type="dept" install_configure_form.stanford_sites_tmpdir="sites/default/files/tmp" install_configure_form.enable_webauth=1 install_configure_form.stanford_sites_requester_email="jbickar@stanford.edu" install_configure_form.stanford_sites_requester_name="John Bickar" install_configure_form.stanford_sites_requester_sunetid="jbickar" install_configure_form.itasks_extra_tasks="sites" --account-name="admin" --account-mail="sws-developers@lists.stanford.edu" install_configure_form.update_status_module=0 --site-name="JSV" --site-mail="sws-developers@lists.stanford.edu"
```
3. Run `drush sqlq 'select * from authmap'` and verify that there is an `authname` entry for `jbickar@stanford.edu`
4. Merge
5. Run `development.sh` in the deployer and have me verify that I can log in and get the site owner role and only one user account.

# Affected Projects or Products
- All JS

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/BASIC-2410
- Other PRs: https://github.com/SU-SWS/stanford_sites_build/pull/8 might block you from doing Step 5, above.
- Anyone who should be notified? ( @pookmish @eolienne )
