### PR TITLE
7.x-1.0-alpha4

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,27 @@
 Stanford Installation Tasks
 --------------------------------------
 
+7.x-1.0-alpha4                     2018-01-24
+---------------------------------------------
+- Updated Get Help and Launch Checklist pages
+
+- For Stanford Sites:
+  - Fix bug where requester was not getting authmap set correctly
+  - Allow to specify the temporary files directory
+
+- For JSA:
+  - Updated BEANs
+  - Add redirect from "login" to "user"
+
+- For JSE:
+  - Update to CAPxConfig.php
+
+- For Jumpstart Lab:
+  - Hide WMD login block
+  - Add redirect from "login" to "user"
+  - Add entry in file_usage table for JS homepage file
+
+
 7.x-1.0-alpha3                     2017-01-20
 ---------------------------------------------
 - For JumpstartLab

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 #[Stanford Installation Tasks](https://github.com/SU-SWS/stanford_install_tasks)
-##### Version: 7.x-1.0-alpha3
+##### Version: 7.x-1.0-alpha4
 
 # iTasks Installation Tasks  
 _A collection of small chunks of code._


### PR DESCRIPTION
# What (Changelog)
- Bug fixes and minor enhancements; see [CHANGELOG](https://github.com/SU-SWS/stanford_install_tasks/blob/7.x-1.x/CHANGELOG.txt)

# So what
- This release is largely to incorporate a bug fix (see [JIRA ticket](https://stanfordits.atlassian.net/browse/BASIC-2410) where the Site Owner's SUNetID was not getting entered into the {{authmap}} table. It includes other changes since `7.x-1.0-alpha3`

# Now what
- We will need to update `stanford-jumpstart-deployer` once this is tagged.

# New Requirements and Risks (Changelog)
- New dependencies: none
- Database updates: none
- Update risks: none
- Potential conflicts with other modules on our stack: none

# Diff
- [Link to diff of all commits of previous release](https://github.com/SU-SWS/stanford_install_tasks/compare/7.x-1.0-alpha3...2c004a5e6334936735829f026cf83b92af4aacd1)

# Assignee for code review
- @sherakama 