### PR TITLE
SITES-837: Enable the default context.

### DIFF
--- a/Stanford/JumpstartLab/Install/HomePageSettings.php
+++ b/Stanford/JumpstartLab/Install/HomePageSettings.php
@@ -36,6 +36,11 @@ class HomePageSettings extends AbstractInstallTask {
     variable_set('stanford_jumpstart_home_active_body_class', 'stanford-jumpstart-home-mayfield-lab');
     variable_set('context_status', $context_status);
 
+    // Enable the default context.
+    $context = context_load($default);
+    $context->disabled = FALSE;
+    context_save($context);
+
     foreach ($names as $context_name) {
       $context_status[$context_name] = TRUE;
       $settings = variable_get('sjh_' . $context_name, array());


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Enables the default context for Lab.
- See https://github.com/SU-SWS/stanford_jumpstart_home/pull/32

# Needed By (Date)
- Everything with migration is soonish.

# Urgency
- See above

# Steps to Test

1. Check out this branch
2. Check out branch in https://github.com/SU-SWS/stanford_jumpstart_home/pull/32
3. Install stanford_sites_jumpstart_lab profile
4. Validate the default homepage layout is enabled and loading

# Affected Projects or Products
- Migration
- Labs

# Associated Issues and/or People
- SITES-837

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)