### PR TITLE
SITES-359: Enable syslog at install

### DIFF
--- a/Environment/ACSF/Install/EnableModules.php
+++ b/Environment/ACSF/Install/EnableModules.php
@@ -35,7 +35,7 @@ class EnableModules extends AbstractInstallTask {
       'paranoia',
       'stanford_ssp',
       'stanford_saml_block',
-      'syslog'
+      'syslog',
     );
   }
 

--- a/Environment/ACSF/Install/EnableModules.php
+++ b/Environment/ACSF/Install/EnableModules.php
@@ -34,7 +34,8 @@ class EnableModules extends AbstractInstallTask {
       'acsf_helper',
       'paranoia',
       'stanford_ssp',
-      'stanford_saml_block'
+      'stanford_saml_block',
+      'syslog'
     );
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Just what it says on the tin

# Needed By (Date)
- Meh

# Criticality
- Meh

# Steps to Test

1. Install a JS* product
2. `drush pmi syslog` returns `Not installed`
3. Plop this branch into `acsf-cardinald7`
4. If on local, add `AH_SITE_ENVIRONMENT=foo` to your `.env` file
5. `lando rebuild`
6. `lando restart`, if necessary
7. `lando drush -y si stanford_sites_jumpstart`
8. Wait a decade
9. `lando drush pmi syslog` should return `Enabled`
10. Rinse and repeat for other JS* profiles
11. Sob quietly while lando robs you of what's left of your youth

# Affected Projects or Products
- ACSF

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-359
- Other PRs:
    - https://github.com/SU-SWS/acsf-cardinald7/pull/101
    - https://github.com/SU-SWS/acsf-leland/pull/17
    - https://github.com/SU-SWS/Stanford-Drupal-Profile/pull/110

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)