### PR TITLE
SITES-1105: Set the default timezone to America/Los_Angeles

### DIFF
--- a/Stanford/DrupalProfile/Install/DateTimeSettings.php
+++ b/Stanford/DrupalProfile/Install/DateTimeSettings.php
@@ -20,6 +20,8 @@ class DateTimeSettings extends AbstractInstallTask {
     variable_set('configurable_timezones', 0);
     // Set the first day of the week to Sunday.
     variable_set('date_first_day', 0);
+    // Set the default timezone to America/Los Angeles.
+    variable_set('date_default_timezone', 'America/Los_Angeles');
   }
 
   /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Set the default timezone to America/Los_Angeles

# Needed By (Date)
- A time long long ago...

# Criticality
- High

# Steps to Test

1. Install a JS* product
2. Make sure the timezone is set to `America/Los Angeles`

# Affected Projects or Products
- ACSF

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SITES-1105

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)