### PR TITLE
7.x-1.6

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 Stanford Installation Tasks
 --------------------------------------
 
+7.x-1.6                            2019-01-11
+---------------------------------------------
+- Changed sites.stanford.edu/jsa-content to jsa-content.stanford.edu to avoid redirects and issues with importing content.
+
 7.x-1.5                            2018-12-03
 ---------------------------------------------
 - Set the default timezone to America/Los Angeles.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # [Stanford Installation Tasks](https://github.com/SU-SWS/stanford_install_tasks)
-##### Version: 7.x-1.6-dev
+##### Version: 7.x-1.6
 
 # iTasks Installation Tasks  
 _A collection of small chunks of code._


### PR DESCRIPTION
Please tag and release:
```
- Changed sites.stanford.edu/jsa-content to jsa-content.stanford.edu to avoid redirects and issues with importing content.
```
