### PR TITLE
Update ImporterFieldProcessorCustomBody.php

### DIFF
--- a/Stanford/Jumpstart/Install/Content/Importer/ImporterFieldProcessorCustomBody.php
+++ b/Stanford/Jumpstart/Install/Content/Importer/ImporterFieldProcessorCustomBody.php
@@ -20,16 +20,16 @@ class ImporterFieldProcessorCustomBody extends \ImporterFieldProcessor {
   public function process(&$entity, $entity_type, $field_name) {
     if ($entity_type == "node") {
       if (isset($entity->{$field_name}[LANGUAGE_NONE][0]['value'])) {
-        $entity->{$field_name}[LANGUAGE_NONE][0]['value'] = str_replace('/sites/jsa-content', '=\"https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['value']);
+        $entity->{$field_name}[LANGUAGE_NONE][0]['value'] = str_replace('/sites/jsa-content', 'https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['value']);
       }
       if (isset($entity->{$field_name}[LANGUAGE_NONE][0]['summary'])) {
-        $entity->{$field_name}[LANGUAGE_NONE][0]['summary'] = str_replace('/sites/jsa-content', '=\"https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['summary']);
+        $entity->{$field_name}[LANGUAGE_NONE][0]['summary'] = str_replace('/sites/jsa-content', 'https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['summary']);
       }
       if (isset($entity->{$field_name}[LANGUAGE_NONE][0]['safe_value'])) {
-        $entity->{$field_name}[LANGUAGE_NONE][0]['safe_value'] = str_replace('/sites/jsa-content', '=\"https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['safe_value']);
+        $entity->{$field_name}[LANGUAGE_NONE][0]['safe_value'] = str_replace('/sites/jsa-content', 'https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['safe_value']);
       }
       if (isset($entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary'])) {
-        $entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary'] = str_replace('/sites/jsa-content', '=\"https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary']);
+        $entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary'] = str_replace('/sites/jsa-content', 'https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary']);
       }
     }
   }

--- a/Stanford/Jumpstart/Install/Content/Importer/ImporterFieldProcessorCustomBody.php
+++ b/Stanford/Jumpstart/Install/Content/Importer/ImporterFieldProcessorCustomBody.php
@@ -20,16 +20,16 @@ class ImporterFieldProcessorCustomBody extends \ImporterFieldProcessor {
   public function process(&$entity, $entity_type, $field_name) {
     if ($entity_type == "node") {
       if (isset($entity->{$field_name}[LANGUAGE_NONE][0]['value'])) {
-        $entity->{$field_name}[LANGUAGE_NONE][0]['value'] = str_replace('/jsa-content', 'https://jsa-content.stanford.edu', $entity->{$field_name}[LANGUAGE_NONE][0]['value']);
+        $entity->{$field_name}[LANGUAGE_NONE][0]['value'] = str_replace('=\"/sites/jsa-content', '=\"https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['value']);
       }
       if (isset($entity->{$field_name}[LANGUAGE_NONE][0]['summary'])) {
-        $entity->{$field_name}[LANGUAGE_NONE][0]['summary'] = str_replace('/jsa-content', 'https://jsa-content.stanford.edu', $entity->{$field_name}[LANGUAGE_NONE][0]['summary']);
+        $entity->{$field_name}[LANGUAGE_NONE][0]['summary'] = str_replace('=\"/sites/jsa-content', '=\"https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['summary']);
       }
       if (isset($entity->{$field_name}[LANGUAGE_NONE][0]['safe_value'])) {
-        $entity->{$field_name}[LANGUAGE_NONE][0]['safe_value'] = str_replace('/jsa-content', 'https://jsa-content.stanford.edu', $entity->{$field_name}[LANGUAGE_NONE][0]['safe_value']);
+        $entity->{$field_name}[LANGUAGE_NONE][0]['safe_value'] = str_replace('=\"/sites/jsa-content', '=\"https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['safe_value']);
       }
       if (isset($entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary'])) {
-        $entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary'] = str_replace('/jsa-content', 'https://jsa-content.stanford.edu', $entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary']);
+        $entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary'] = str_replace('=\"/sites/jsa-content', '=\"https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary']);
       }
     }
   }

--- a/Stanford/Jumpstart/Install/Content/Importer/ImporterFieldProcessorCustomBody.php
+++ b/Stanford/Jumpstart/Install/Content/Importer/ImporterFieldProcessorCustomBody.php
@@ -20,16 +20,16 @@ class ImporterFieldProcessorCustomBody extends \ImporterFieldProcessor {
   public function process(&$entity, $entity_type, $field_name) {
     if ($entity_type == "node") {
       if (isset($entity->{$field_name}[LANGUAGE_NONE][0]['value'])) {
-        $entity->{$field_name}[LANGUAGE_NONE][0]['value'] = str_replace('=\"/sites/jsa-content', '=\"https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['value']);
+        $entity->{$field_name}[LANGUAGE_NONE][0]['value'] = str_replace('/sites/jsa-content', '=\"https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['value']);
       }
       if (isset($entity->{$field_name}[LANGUAGE_NONE][0]['summary'])) {
-        $entity->{$field_name}[LANGUAGE_NONE][0]['summary'] = str_replace('=\"/sites/jsa-content', '=\"https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['summary']);
+        $entity->{$field_name}[LANGUAGE_NONE][0]['summary'] = str_replace('/sites/jsa-content', '=\"https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['summary']);
       }
       if (isset($entity->{$field_name}[LANGUAGE_NONE][0]['safe_value'])) {
-        $entity->{$field_name}[LANGUAGE_NONE][0]['safe_value'] = str_replace('=\"/sites/jsa-content', '=\"https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['safe_value']);
+        $entity->{$field_name}[LANGUAGE_NONE][0]['safe_value'] = str_replace('/sites/jsa-content', '=\"https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['safe_value']);
       }
       if (isset($entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary'])) {
-        $entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary'] = str_replace('=\"/sites/jsa-content', '=\"https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary']);
+        $entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary'] = str_replace('/sites/jsa-content', '=\"https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary']);
       }
     }
   }

--- a/Stanford/Jumpstart/Install/Content/Importer/ImporterFieldProcessorCustomBody.php
+++ b/Stanford/Jumpstart/Install/Content/Importer/ImporterFieldProcessorCustomBody.php
@@ -20,16 +20,16 @@ class ImporterFieldProcessorCustomBody extends \ImporterFieldProcessor {
   public function process(&$entity, $entity_type, $field_name) {
     if ($entity_type == "node") {
       if (isset($entity->{$field_name}[LANGUAGE_NONE][0]['value'])) {
-        $entity->{$field_name}[LANGUAGE_NONE][0]['value'] = str_replace('/sites/jsa-content', 'https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['value']);
+        $entity->{$field_name}[LANGUAGE_NONE][0]['value'] = str_replace('="/sites/jsa-content', '="https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['value']);
       }
       if (isset($entity->{$field_name}[LANGUAGE_NONE][0]['summary'])) {
-        $entity->{$field_name}[LANGUAGE_NONE][0]['summary'] = str_replace('/sites/jsa-content', 'https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['summary']);
+        $entity->{$field_name}[LANGUAGE_NONE][0]['summary'] = str_replace('="/sites/jsa-content', '="https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['summary']);
       }
       if (isset($entity->{$field_name}[LANGUAGE_NONE][0]['safe_value'])) {
-        $entity->{$field_name}[LANGUAGE_NONE][0]['safe_value'] = str_replace('/sites/jsa-content', 'https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['safe_value']);
+        $entity->{$field_name}[LANGUAGE_NONE][0]['safe_value'] = str_replace('="/sites/jsa-content', '="https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['safe_value']);
       }
       if (isset($entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary'])) {
-        $entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary'] = str_replace('/sites/jsa-content', 'https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary']);
+        $entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary'] = str_replace('="/sites/jsa-content', '="https://jsa-content.stanford.edu/sites/jsa-content/', $entity->{$field_name}[LANGUAGE_NONE][0]['safe_summary']);
       }
     }
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Updates the string replace logic for new paths in sites-pro
- Urls from jsa-content that are like `src="/sites/jsa-content/files/styles/medium/pic.jpg"` were being incorrectly replaced to `src="/sites/https://jsa-content.stanford.edu/files/styles/medium/pic.jpg"`.
- This fix should produce urls like  `src="https://jsa-content.stanford.edu/sites/jsa-content/files/styles/medium/pic.jpg"`

# Needed By (Date)
- Caryl?

# Urgency
- Caryl?

# Steps to Test

1. Clone down the cardinald7 repo
2. Check out this branch
3. Install a jumpstart site `drush si stanford_sites_jumpstart`
4. Navigate to the people page `/people` and review url for the image in the body field.

# Affected Projects or Products
- Jumpstart products

# Associated Issues and/or People
- JUMP-3191
- @cjwest 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)